### PR TITLE
Fix PHPStan memory limit in CI

### DIFF
--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -12,8 +12,8 @@ cd "$PROJECT_ROOT"
 echo "Running PHPStan static analysis..."
 echo "Project root: $PROJECT_ROOT"
 
-# Run PHPStan
-./vendor/bin/phpstan analyse --no-progress "$@"
+# Run PHPStan with increased memory limit
+./vendor/bin/phpstan analyse --no-progress --memory-limit=512M "$@"
 
 echo ""
 echo "PHPStan analysis completed successfully!"


### PR DESCRIPTION
PHPStan crashes with default 128M memory limit on CI. Increase to 512M to match PHPUnit configuration.