### PR TITLE
refactor: rename .tools to @tools and fix PHAR build

### DIFF
--- a/@tools/Packages/Phar.make.php
+++ b/@tools/Packages/Phar.make.php
@@ -40,8 +40,8 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 				// Convert absolute path to relative path
 				$relativePath = str_replace(__DIR__ . '/../../', '', $path);
 
-				// Skip certain directories
-				if (!preg_match('/^(@tools|.git)/', $relativePath)) {
+// Skip certain directories
+			if (!preg_match('/^(@tools|vendor|tests|@phpdocs|build|\.phpdoc|\.git)/', $relativePath)) {
 					$includes[] = $relativePath;
 				}
 			}
@@ -68,7 +68,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 		$p->setStub('<?php
 Phar::mapPhar("' . FILENAME_PHAR . '");
-require_once "phar://' . FILENAME_PHAR . '/vendor/autoload.php";
+require_once "' . __DIR__ . '/../../vendor/autoload.php";
 __HALT_COMPILER();');
 		fwrite(STDERR, 'PHAR file created successfully: ' . FILEPATH_PHAR . PHP_EOL);
 	} else {

--- a/@tools/regenerate.all
+++ b/@tools/regenerate.all
@@ -22,4 +22,4 @@ php -d phar.readonly=0 ./Packages/Phar.test.php
 # This command in: https://github.com/Hubbitus/shell.scripts
 # ./generate-phpdoc.sh
 
-} 2>&1 | tee ${PROJECT_ROOT}/.tools/regenerate.all.log
+} 2>&1 | tee ${PROJECT_ROOT}/@tools/regenerate.all.log


### PR DESCRIPTION
## Summary
- Renamed `.tools` to `@tools` to work around PHPDocumentor v3 bug (can't ignore directories starting with dot)
- Fixed PHAR build to exclude vendor (5000+ files was too slow)
- Fixed stub to require external vendor/autoload.php
- Updated all references in README.md, workflows, and config files