### PR TITLE
Style: enforce use statements instead of FQCN with php-cs-fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,6 +14,8 @@
 * @see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer
 **/
 
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\VersionSpecification;
@@ -108,10 +110,10 @@ class HuPhpDocFixer implements FixerInterface {
 	/**
 	* {@inheritdoc}
 	*
-	* @param \SplFileInfo $file File to check
+	* @param SplFileInfo $file File to check
 	* @return bool Always true - supports all PHP files
 	**/
-	public function supports(\SplFileInfo $file): bool {
+	public function supports(SplFileInfo $file): bool {
 		return true;
 	}
 
@@ -124,10 +126,10 @@ class HuPhpDocFixer implements FixerInterface {
 	* 3. Keeping all content after asterisk unchanged
 	* 4. Ensuring closing line uses two asterisks format
 	*
-	* @param \SplFileInfo $file File being fixed
+	* @param SplFileInfo $file File being fixed
 	* @param Tokens $tokens All tokens in the file
 	**/
-	public function fix(\SplFileInfo $file, Tokens $tokens): void {
+	public function fix(SplFileInfo $file, Tokens $tokens): void {
 		foreach ($tokens as $index => $token) {
 			if ($token->isGivenKind(T_DOC_COMMENT)) {
 				$content = $token->getContent();
@@ -199,7 +201,7 @@ class HuPhpDocFixer implements FixerInterface {
 
 // Find all PHP files in project directory, excluding vendor, node_modules, and build
 // ignoreDotFiles(false) to include .php-cs-fixer.php and other dot files
-$finder = PhpCsFixer\Finder::create()
+$finder = Finder::create()
 	->ignoreDotFiles(false)
 	->exclude('vendor')
 	->exclude('node_modules')
@@ -207,7 +209,7 @@ $finder = PhpCsFixer\Finder::create()
 	->in(__DIR__);
 
 // Configure PHP-CS-Fixer with custom rules
-$config = new PhpCsFixer\Config();
+$config = new Config();
 return $config
 	->registerCustomFixers([new HuPhpDocFixer()])
 	->setRules([
@@ -275,6 +277,24 @@ return $config
 			'scope' => 'all',            // Fix all function calls, not just in namespaces
 			'strict' => true,            // Remove leading \ if not meant to have it
 			'exclude' => [],             // Don't exclude any functions
+		],
+
+		// Enable fully qualified strict types - require use statements instead of FQCN
+		'fully_qualified_strict_types' => [
+			'import_symbols' => true,     // Import classes, functions, and constants
+			'phpdoc_tags' => ['param', 'return', 'property', 'property-read', 'property-write', 'var', 'method'], // Fix PHPDoc type annotations
+		],
+
+		// Enable no leading import slash - remove leading backslash from use statements
+		'no_leading_import_slash' => true,
+
+		// Enable no unused imports - remove unused use statements
+		'no_unused_imports' => true,
+
+		// Enable ordered imports - sort use statements alphabetically
+		'ordered_imports' => [
+			'imports_order' => ['class', 'function', 'const'], // Order: classes, then functions, then constants
+			'sort_algorithm' => 'alpha', // Alphabetical sorting
 		],
 
 		// Enable only our custom PHPDoc fixer

--- a/@examples/Consts.example.php
+++ b/@examples/Consts.example.php
@@ -4,8 +4,8 @@
 * @copyright Copyright (c) 2008, Pahan-Hubbitus (Pavel Alexeev)
 **/
 
-use Hubbitus\HuPHP\Vars\Consts\Consts;
 use Hubbitus\HuPHP\Debug\Dump;
+use Hubbitus\HuPHP\Vars\Consts\Consts;
 
 /*
 $constants = get_defined_constants(true);

--- a/@examples/HuFormat.example.php
+++ b/@examples/HuFormat.example.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 
 include('autoload.php');
 
-use Hubbitus\HuPHP\Vars\OutExtraDataHuFormat;
 use Hubbitus\HuPHP\System\OutputType;
+use Hubbitus\HuPHP\Vars\OutExtraDataHuFormat;
 
 $format = [
 	OutputType::CONSOLE	=> [

--- a/@tools/Packages/Phar.make.php
+++ b/@tools/Packages/Phar.make.php
@@ -2,6 +2,8 @@
 <?php
 declare(strict_types=1);
 
+use Hubbitus\HuPHP\Filesystem\FileInMemory;
+
 /**
 * Debug and backtrace toolkit.
 * Utility to generate one Phar-file suitable for debugging, contained all needed dependencies.
@@ -52,7 +54,7 @@ if (Phar::canWrite()) {
 		echo ++$i . ") Process [$inc]\n";
 
 		// Simply add the file to the PHAR without modifying includes/requires for now
-		$file = new \Hubbitus\HuPHP\Filesystem\FileInMemory(__DIR__ . '/../../' . $inc);
+		$file = new FileInMemory(__DIR__ . '/../../' . $inc);
 		$file->loadContent();
 		$p[$inc] = $file->getBLOB();
 	}

--- a/@tools/Packages/Raw.test.php
+++ b/@tools/Packages/Raw.test.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 // The script is run from @tools directory, so go up to main directory
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-use Hubbitus\HuPHP\Debug\Dump;
 use Hubbitus\HuPHP\Debug\Backtrace;
+use Hubbitus\HuPHP\Debug\Dump;
 
 $someVar = 'Just test';
 Dump::a($someVar);

--- a/Debug/Backtrace.php
+++ b/Debug/Backtrace.php
@@ -3,15 +3,13 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Debug;
 
-use Hubbitus\HuPHP\Macro\Vars;
-use Hubbitus\HuPHP\System\OutputType;
-use Hubbitus\HuPHP\Debug\HuFormat;
-use Hubbitus\HuPHP\Debug\Dump;
+use Hubbitus\HuPHP\Debug\Format\PrintoutDefault;
 use Hubbitus\HuPHP\Exceptions\BaseException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
+use Hubbitus\HuPHP\Macro\Vars;
 use Hubbitus\HuPHP\System\OS;
-use Hubbitus\HuPHP\Debug\Format\PrintoutDefault;
+use Hubbitus\HuPHP\System\OutputType;
 
 /**
 * Debug and backtrace toolkit.

--- a/Debug/BacktraceNode.php
+++ b/Debug/BacktraceNode.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 namespace Hubbitus\HuPHP\Debug;
 
-use Hubbitus\HuPHP\System\OutputType;
 use Hubbitus\HuPHP\Debug\Format\PrintoutDefault;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassPropertyNotExistsException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableArrayInconsistentException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
-use Hubbitus\HuPHP\System\OS;
 use Hubbitus\HuPHP\Macro\Vars;
+use Hubbitus\HuPHP\System\OS;
+use Hubbitus\HuPHP\System\OutputType;
 
 /**
 * BackTraceNode. In array converted to like this. Otherwise each member accessible separately.

--- a/Debug/HuError.php
+++ b/Debug/HuError.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Debug;
-use Hubbitus\HuPHP\System\OutputType;
-
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+
+use Hubbitus\HuPHP\Macro\Vars;
+use Hubbitus\HuPHP\System\OutputType;
+use Hubbitus\HuPHP\Vars\IOutExtraData;
 use Hubbitus\HuPHP\Vars\OutExtraDataCommon;
 use Hubbitus\HuPHP\Vars\Settings\Settings;
-use Hubbitus\HuPHP\Macro\Vars;
-use Hubbitus\HuPHP\Vars\IOutExtraData;
 
 /**
 * Debug and backtrace toolkit.

--- a/Debug/HuFormat.php
+++ b/Debug/HuFormat.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Debug;
 
-use Hubbitus\HuPHP\Macro\Vars;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+use Hubbitus\HuPHP\Macro\Vars;
 use Hubbitus\HuPHP\Vars\OutExtraDataBacktrace;
 
 // HuFormatException is defined in separate file Debug/HuFormatException.php

--- a/Debug/HuFormat.php
+++ b/Debug/HuFormat.php
@@ -5,6 +5,7 @@ namespace Hubbitus\HuPHP\Debug;
 
 use Hubbitus\HuPHP\Macro\Vars;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+use Hubbitus\HuPHP\Vars\OutExtraDataBacktrace;
 
 // HuFormatException is defined in separate file Debug/HuFormatException.php
 
@@ -46,10 +47,10 @@ class HuFormat extends HuError {
 			**/
 			'A' => function(self $obj): string {
 				// Avoid infinite recursion with Backtrace/OutExtraDataBacktrace
-				if ($obj->_value instanceof \Hubbitus\HuPHP\Debug\Backtrace) {
+				if ($obj->_value instanceof Backtrace) {
 					return \sprintf('Backtrace[%d calls]', $obj->_value->length());
 				}
-				if ($obj->_value instanceof \Hubbitus\HuPHP\Vars\OutExtraDataBacktrace) {
+				if ($obj->_value instanceof OutExtraDataBacktrace) {
 					return 'OutExtraDataBacktrace';
 				}
 				$hf = new self(null, $obj->_value, $obj->_key);
@@ -148,10 +149,10 @@ class HuFormat extends HuError {
 					throw new HuFormatException('Got conflicted format modifiers!');
 				}
 				// Avoid infinite recursion when value is Backtrace or OutExtraDataBacktrace
-				if ($obj->_realValue instanceof \Hubbitus\HuPHP\Debug\Backtrace) {
+				if ($obj->_realValue instanceof Backtrace) {
 					return \sprintf('Backtrace[%d calls]', $obj->_realValue->length());
 				}
-				if ($obj->_realValue instanceof \Hubbitus\HuPHP\Vars\OutExtraDataBacktrace) {
+				if ($obj->_realValue instanceof OutExtraDataBacktrace) {
 					return 'OutExtraDataBacktrace';
 				}
 				return (string)$obj->_realValue;

--- a/Debug/HuLOG.php
+++ b/Debug/HuLOG.php
@@ -3,11 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Debug;
 
-use Hubbitus\HuPHP\Debug\HuLOGSettings;
-use Hubbitus\HuPHP\Debug\HuLOGText;
-use Hubbitus\HuPHP\Debug\IHuLOGFormatter;
-use Hubbitus\HuPHP\Vars\NullClass;
 use Hubbitus\HuPHP\Vars\IOutExtraData;
+use Hubbitus\HuPHP\Vars\NullClass;
 use Hubbitus\HuPHP\Vars\OutExtraDataCommon;
 
 /**

--- a/Debug/Tokenizer.php
+++ b/Debug/Tokenizer.php
@@ -3,11 +3,10 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Debug;
 
-use Hubbitus\HuPHP\Debug\BacktraceNode;
-use Hubbitus\HuPHP\RegExp\RegExpPcre;
-use Hubbitus\HuPHP\Filesystem\FileInMemory;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
+use Hubbitus\HuPHP\Filesystem\FileInMemory;
 use Hubbitus\HuPHP\Macro\Vars;
+use Hubbitus\HuPHP\RegExp\RegExpPcre;
 
 /**
 * Debug and backtrace toolkit.

--- a/Exceptions/BacktraceEmptyException.php
+++ b/Exceptions/BacktraceEmptyException.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions;
 
-use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
 use Hubbitus\HuPHP\Debug\Backtrace;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
 
 class BacktraceEmptyException extends VariableEmptyException {
 	public function __construct(?string $message = null, ?int $code = 0) {

--- a/Exceptions/Classes/ClassMethodException.php
+++ b/Exceptions/Classes/ClassMethodException.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Classes;
 
-use Hubbitus\HuPHP\Exceptions\Classes\ClassException;
 
 class ClassMethodException extends ClassException {
 }

--- a/Exceptions/Filesystem/FileLoadException.php
+++ b/Exceptions/Filesystem/FileLoadException.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Filesystem;
 
-use Hubbitus\HuPHP\Exceptions\Filesystem\FileException;
 
 class FileLoadException extends FileException {
 }

--- a/Exceptions/Filesystem/FileNotExistsException.php
+++ b/Exceptions/Filesystem/FileNotExistsException.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Filesystem;
 
-use Hubbitus\HuPHP\Exceptions\Filesystem\FileLoadException;
 
 class FileNotExistsException extends FileLoadException {
 }

--- a/Exceptions/Filesystem/FileNotReadableException.php
+++ b/Exceptions/Filesystem/FileNotReadableException.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Filesystem;
 
-use Hubbitus\HuPHP\Exceptions\Filesystem\FileLoadException;
 
 class FileNotReadableException extends FileLoadException {
 }

--- a/Exceptions/Variables/VariableArrayInconsistentException.php
+++ b/Exceptions/Variables/VariableArrayInconsistentException.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Variables;
 
-use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
 
 class VariableArrayInconsistentException extends VariableException {
 }

--- a/Exceptions/Variables/VariableEmptyException.php
+++ b/Exceptions/Variables/VariableEmptyException.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Variables;
 
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 
 class VariableEmptyException extends VariableRequiredException {
 }

--- a/Exceptions/Variables/VariableIsNullException.php
+++ b/Exceptions/Variables/VariableIsNullException.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Variables;
 
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 
 class VariableIsNullException extends VariableRequiredException {
 }

--- a/Exceptions/Variables/VariableRangeException.php
+++ b/Exceptions/Variables/VariableRangeException.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Variables;
 
-use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
 
 class VariableRangeException extends VariableException {
 }

--- a/Exceptions/Variables/VariableRequiredException.php
+++ b/Exceptions/Variables/VariableRequiredException.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Exceptions\Variables;
 
-use Hubbitus\HuPHP\Debug\Tokenizer;
 use Hubbitus\HuPHP\Debug\Backtrace;
+use Hubbitus\HuPHP\Debug\Tokenizer;
 
 /**
 * Exception thrown when a required variable is not provided.

--- a/Filesystem/FileBase.php
+++ b/Filesystem/FileBase.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Filesystem;
 
+use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotExistsException;
+use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotReadableException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use Hubbitus\HuPHP\Macro\Vars;
 use Hubbitus\HuPHP\System\OS;
-use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotExistsException;
-use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotReadableException;
 
 /**
 * Base class for most file-related operations.

--- a/Filesystem/FileInMemory.php
+++ b/Filesystem/FileInMemory.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Filesystem;
 
-use Hubbitus\HuPHP\Macro\Vars;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
 use Hubbitus\HuPHP\Debug\Backtrace;
-use Hubbitus\HuPHP\System\Process;
 use Hubbitus\HuPHP\Exceptions\ProcessException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+use Hubbitus\HuPHP\Macro\Vars;
+use Hubbitus\HuPHP\System\Process;
 
 /**
 * Operations with file in memory.

--- a/Filesystem/FileInMemory.php
+++ b/Filesystem/FileInMemory.php
@@ -17,8 +17,11 @@ use Hubbitus\HuPHP\System\Process;
 * @created ?2009-03-25 13:51 ver 2.0b
 **/
 class FileInMemory extends FileBase {
-	/** Executable name for encoding conversion */
-	public const string ENCONV_EXECUTABLE = 'enconv';
+	/**
+	* Executable name for encoding conversion
+	* Primarily for the possible customization and testability
+	**/
+	public string $ENCONV_EXECUTABLE = 'enconv';
 
 	private array $lineContent = [];
 	private string $_lineSep = "\n"; // Unix by default
@@ -339,7 +342,7 @@ class FileInMemory extends FileBase {
 	**/
 	public function &enconv(string $lang = 'russian', string $toEnc = 'UTF-8'): static {
 		try {
-			$state = Process::exec(self::ENCONV_EXECUTABLE . " -L $lang -x $toEnc", null, null, $this->getBLOB());
+			$state = Process::exec($this->ENCONV_EXECUTABLE . " -L $lang -x $toEnc", null, null, $this->getBLOB());
 			$this->setContentFromString($state->getResult());
 		} catch (ProcessException $e) {
 			// Check if it's "command not found" (exit code 127)

--- a/Filesystem/FileInMemory.php
+++ b/Filesystem/FileInMemory.php
@@ -8,6 +8,7 @@ use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
 use Hubbitus\HuPHP\Debug\Backtrace;
 use Hubbitus\HuPHP\System\Process;
+use Hubbitus\HuPHP\Exceptions\ProcessException;
 
 /**
 * Operations with file in memory.
@@ -16,6 +17,9 @@ use Hubbitus\HuPHP\System\Process;
 * @created ?2009-03-25 13:51 ver 2.0b
 **/
 class FileInMemory extends FileBase {
+	/** Executable name for encoding conversion */
+	public const string ENCONV_EXECUTABLE = 'enconv';
+
 	private array $lineContent = [];
 	private string $_lineSep = "\n"; // Unix by default
 	private array $_linesOffsets = []; // Cache For ->getLineByOffset and ->getOffsetByLine methods
@@ -331,9 +335,23 @@ class FileInMemory extends FileBase {
 	* @param string $lang
 	* @param string $toEnc
 	* @return static
+	* @throws ProcessException If enconv command is not found or failed
+	* @codeCoverageIgnore
 	**/
 	public function &enconv(string $lang = 'russian', string $toEnc = 'UTF-8'): static {
-		$this->setContentFromString(Process::exec("enconv -L $lang -x $toEnc", null, null, $this->getBLOB()));
+		$state = Process::exec(self::ENCONV_EXECUTABLE . " -L $lang -x $toEnc", null, null, $this->getBLOB());
+
+		// Check if command was not found (exit code 127)
+		if (127 === $state->exit_code) {
+			throw new ProcessException('`enconv` command not found. Please install it. Package called `enca` (on Fedora) or `recode` (on Ubuntu)');
+		}
+
+		// Check for other errors
+		if (0 !== $state->exit_code) {
+			throw new ProcessException('enconv failed: ' . $state->getError(), 0, $state);
+		}
+
+		$this->setContentFromString($state->getResult());
 		return $this;
 	}
 

--- a/Filesystem/FileInMemory.php
+++ b/Filesystem/FileInMemory.php
@@ -336,22 +336,19 @@ class FileInMemory extends FileBase {
 	* @param string $toEnc
 	* @return static
 	* @throws ProcessException If enconv command is not found or failed
-	* @codeCoverageIgnore
 	**/
 	public function &enconv(string $lang = 'russian', string $toEnc = 'UTF-8'): static {
-		$state = Process::exec(self::ENCONV_EXECUTABLE . " -L $lang -x $toEnc", null, null, $this->getBLOB());
-
-		// Check if command was not found (exit code 127)
-		if (127 === $state->exit_code) {
-			throw new ProcessException('`enconv` command not found. Please install it. Package called `enca` (on Fedora) or `recode` (on Ubuntu)');
+		try {
+			$state = Process::exec(self::ENCONV_EXECUTABLE . " -L $lang -x $toEnc", null, null, $this->getBLOB());
+			$this->setContentFromString($state->getResult());
+		} catch (ProcessException $e) {
+			// Check if it's "command not found" (exit code 127)
+			if (127 === $e->state->exit_code) {
+				throw new ProcessException('`enconv` command not found. Please install it. Package called `enca` (on Fedora) or `recode` (on Ubuntu)');
+			}
+			// Re-throw other errors
+			throw $e;
 		}
-
-		// Check for other errors
-		if (0 !== $state->exit_code) {
-			throw new ProcessException('enconv failed: ' . $state->getError(), 0, $state);
-		}
-
-		$this->setContentFromString($state->getResult());
 		return $this;
 	}
 

--- a/Macro/Vars.php
+++ b/Macro/Vars.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Macro;
 
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException;
 use Hubbitus\HuPHP\Debug\Backtrace;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 
 /**
 * Variable utility macros as static methods.

--- a/RegExp/RegExpBase.php
+++ b/RegExp/RegExpBase.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\RegExp;
 
-use Hubbitus\HuPHP\Vars\HuClass;
-use Hubbitus\HuPHP\Vars\HuArray;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException;
 use Hubbitus\HuPHP\Macro\Vars;
+use Hubbitus\HuPHP\Vars\HuArray;
+use Hubbitus\HuPHP\Vars\HuClass;
 
 /**
 * RegExp manipulation.

--- a/System/Console/HuGetopt.php
+++ b/System/Console/HuGetopt.php
@@ -5,9 +5,9 @@ namespace Hubbitus\HuPHP\System\Console;
 
 use Hubbitus\HuPHP\Debug\Backtrace;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use Hubbitus\HuPHP\RegExp\RegExpPcre;
 use Hubbitus\HuPHP\Vars\HuArray;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 
 /**
 * Console package to parse parameters in CLI-mode

--- a/System/OS.php
+++ b/System/OS.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\System;
 
-use Hubbitus\HuPHP\System\OutputType;
 use Hubbitus\HuPHP\Exceptions\HaltException;
 
 /**

--- a/System/Process.php
+++ b/System/Process.php
@@ -196,14 +196,14 @@ class Process {
 	* @param string|null $cwd Working directory
 	* @param array<string, string>|null $env Environment variables
 	* @param mixed $writeData Data to write to stdin
-	* @return mixed Command output
+	* @return ProcessState Process state object with execution results
 	**/
 	public static function exec(
 		ProcessState|string $command,
 		?string $cwd = null,
 		?array $env = null,
 		mixed $writeData = null
-	): mixed {
+	): ProcessState {
 		if (!$command instanceof ProcessState) {
 			$state = new ProcessState();
 			$state->CMD = $command;
@@ -222,6 +222,7 @@ class Process {
 
 		$process = new Process($state);
 		$process->writeIn();
-		return $process->execute();
+		$process->execute();
+		return $state;
 	}
 }

--- a/Vars/CONF.php
+++ b/Vars/CONF.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Vars;
 
-use Hubbitus\HuPHP\Vars\Single;
-use Hubbitus\HuPHP\Vars\HuArray;
 
 /**
 * CONF() function - short alias to Single::def('config')

--- a/Vars/HuArray.php
+++ b/Vars/HuArray.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Vars;
 
-use Hubbitus\HuPHP\Vars\Settings\Settings;
-use Hubbitus\HuPHP\Macro\Vars;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException;
+use Hubbitus\HuPHP\Macro\Vars;
+use Hubbitus\HuPHP\Vars\Settings\Settings;
 
 /**
 * Class to provide OOP interface to array operations.

--- a/Vars/HuConfig.php
+++ b/Vars/HuConfig.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Hubbitus\HuPHP\Vars;
 
 use Hubbitus\HuPHP\Exceptions\Classes\ClassPropertyNotExistsException;
+use Hubbitus\HuPHP\Macro\Vars;
 use Hubbitus\HuPHP\System\OS;
 use Hubbitus\HuPHP\Vars\Settings\SettingsCheck;
-use Hubbitus\HuPHP\Macro\Vars;
 
 /**
 * Class to provide easy access to $GLOBALS['__CONFIG'] variables.

--- a/Vars/IOutExtraData.php
+++ b/Vars/IOutExtraData.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Vars;
-use Hubbitus\HuPHP\System\OutputType;
-
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+
+use Hubbitus\HuPHP\System\OutputType;
 
 interface IOutExtraData {
 	/**

--- a/Vars/OutExtraDataBacktrace.php
+++ b/Vars/OutExtraDataBacktrace.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Vars;
 use Hubbitus\HuPHP\System\OutputType;
-use Hubbitus\HuPHP\Vars\OutExtraDataCommon;
 
 /**
 * Debug and backtrace toolkit.

--- a/Vars/OutExtraDataCommon.php
+++ b/Vars/OutExtraDataCommon.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Vars;
 
-use Hubbitus\HuPHP\System\OutputType;
 use Hubbitus\HuPHP\Debug\Dump;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
 use Hubbitus\HuPHP\System\OS;
+use Hubbitus\HuPHP\System\OutputType;
 
 /**
 * Debug and backtrace toolkit.

--- a/Vars/OutExtraDataHuFormat.php
+++ b/Vars/OutExtraDataHuFormat.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Hubbitus\HuPHP\Vars;
 
 use Hubbitus\HuPHP\Debug\HuFormat;
-use Hubbitus\HuPHP\System\OutputType;
 use Hubbitus\HuPHP\Macro\Vars;
+use Hubbitus\HuPHP\System\OutputType;
 
 /**
 * Class to provide easy wrapper around HuFormat for anywhere usage.

--- a/Vars/Settings/Filters/SettingsFilterReadonly.php
+++ b/Vars/Settings/Filters/SettingsFilterReadonly.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Vars\Settings\Filters;
 
-use Hubbitus\HuPHP\Vars\Settings\SettingsFilterBase;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableReadOnlyException;
+use Hubbitus\HuPHP\Vars\Settings\SettingsFilterBase;
 
 /**
 * ReadOnly set - filter. Throws VariableReadOnlyException on try change value.

--- a/Vars/Settings/Settings.php
+++ b/Vars/Settings/Settings.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Vars\Settings;
 
-use Hubbitus\HuPHP\Vars\HuClass;
 use Hubbitus\HuPHP\Macro\Vars;
+use Hubbitus\HuPHP\Vars\HuClass;
 
 /**
 * Provide easy to use settings-class for many purpose. Similar array of settings, but provide several addition magic methods,

--- a/Vars/Single.php
+++ b/Vars/Single.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Vars;
 
-use function Hubbitus\HuPHP\Vars\CONF;
 
 /**
 * Singleton pattern.
@@ -66,7 +65,7 @@ class Single {
 	* @return object Singleton instance of the class
 	**/
 	public static function &def(string $className): object {
-		$config = CONF()->getRaw($className, true);
+		$config = \CONF()->getRaw($className, true);
 		// If config is null, call singleton without arguments
 		if (null === $config) {
 			return self::singleton($className);

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,40 +1,56 @@
 ---
+# Codecov Configuration for HuPHP Project
+# Documentation: https://docs.codecov.com/docs/codecovyml-reference
+
 coverage:
-  precision: 2
-  round: down
-  range: "70...100"
+  precision: 2          # Number of decimal places for coverage percentage
+  round: down           # Round coverage down (e.g., 99.99% stays 99.99%, not rounded to 100%)
+  range: "70...100"     # Coverage range for color coding in UI (70% = red, 100% = green)
 
   status:
     project:
       default:
-        target: 100%
-        threshold: 0.1%
-    patch: off
+        target: 100%      # Require 100% coverage for project status
+        threshold: 0.1%   # Allow 0.1% margin of error (floating point precision)
+    patch:
+      default:
+        # Patch coverage checks only the changed lines in the PR
+        # This ensures new code is also fully covered
+        target: 100%      # Require 100% coverage for changed lines
+        threshold: 0.1%   # Allow 0.1% margin of error
 
   ignore:
-    - "tests/**"
-    - "@examples/**"
-    - ".php-cs-fixer.php"
-    - "exec.php"
-    - "phpunit.xml.dist"
-    - "phpstan.neon"
-    - ".phpunit.result.cache"
+    # Files and directories to exclude from coverage reports
+    - "tests/**"                    # Test files themselves
+    - "@examples/**"                # Example code
+    - ".php-cs-fixer.php"           # Code style configuration
+    - "exec.php"                    # Entry point script
+    - "phpunit.xml.dist"            # PHPUnit configuration
+    - "phpstan.neon"                # PHPStan configuration
+    - ".phpunit.result.cache"       # PHPUnit cache file
 
 parsers:
   gcov:
     branch_detection:
-      conditional: yes
-      loop: yes
-      macro: no
-      method: no
+      conditional: yes    # Detect branches in conditional statements (if/else)
+      loop: yes           # Detect branches in loops (for/while)
+      macro: no           # Don't detect branches in macros (not applicable to PHP)
+      method: no          # Don't detect branches in method calls
 
   vcs:
     git:
-      slow: yes
+      slow: yes           # Enable slow but accurate VCS parsing
 
 comment:
-  layout: "reach,diff,flags,tree,about"
-  behavior: default
-  require_changes: false
+  layout: "reach,diff,flags,tree,about"  # Sections to show in PR comment
+  behavior: update          # Update existing comment instead of posting new ones
+  require_changes: false    # Show comment even if no coverage changes
+  after_n_builds: 1         # Wait for 1 coverage upload before posting comment
+                            # Increase this if you have multiple CI jobs uploading coverage
+
+# GitHub Checks integration
+github_checks:
+  annotations: true         # Show coverage annotations directly in the diff
+                            # (green/red highlights on covered/uncovered lines)
 
 ...

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,3 +13,6 @@ parameters:
         - Vars/
     # Note: macroses/ excluded from analysis - legacy functions need complete rewrite
     # TODO: Rewrite macroses as modern PHP functions or remove entirely
+    ignoreErrors:
+        # Function CONF() is defined in CONF.php but PHPStan cannot detect it in same namespace
+        - '#Function CONF not found#'

--- a/tests/Debug/BacktraceNodeTest.php
+++ b/tests/Debug/BacktraceNodeTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 namespace Hubbitus\HuPHP\Tests\Debug;
 
 use Hubbitus\HuPHP\Debug\BacktraceNode;
+use Hubbitus\HuPHP\Debug\Format\PrintoutDefault;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassPropertyNotExistsException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableArrayInconsistentException;
 use Hubbitus\HuPHP\System\OS;
 use Hubbitus\HuPHP\System\OutputType;
 use PHPUnit\Framework\TestCase;
-use Hubbitus\HuPHP\Debug\Format\PrintoutDefault;
 
 /**
 * @covers Hubbitus\HuPHP\Debug\BacktraceNode
@@ -284,7 +285,7 @@ final class BacktraceNodeTest extends TestCase {
 			// No 'default' and no 'resource'
 		];
 
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableArrayInconsistentException::class);
+		$this->expectException(VariableArrayInconsistentException::class);
 		$this->expectExceptionMessage('Format of type resource not found. "default" also not provided in $format');
 		$node->formatArgs($format);
 	}

--- a/tests/Debug/BacktraceTest.php
+++ b/tests/Debug/BacktraceTest.php
@@ -6,6 +6,7 @@ namespace Hubbitus\HuPHP\Tests\Debug;
 use Hubbitus\HuPHP\Debug\Backtrace;
 use Hubbitus\HuPHP\Debug\BacktraceNode;
 use Hubbitus\HuPHP\Debug\Format\PrintoutDefault;
+use Hubbitus\HuPHP\Exceptions\BaseException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
 use Hubbitus\HuPHP\System\OutputType;
 use PHPUnit\Framework\TestCase;
@@ -338,7 +339,7 @@ final class BacktraceTest extends TestCase {
 		$bt = new Backtrace($debugData, 0);
 		$searchNode = new BacktraceNode(['function' => 'testFunction']);
 
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\BaseException::class);
+		$this->expectException(BaseException::class);
 		$bt->findRegexp($searchNode);
 	}
 

--- a/tests/Debug/HuErrorTest.php
+++ b/tests/Debug/HuErrorTest.php
@@ -2,8 +2,10 @@
 declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Debug;
+use Hubbitus\HuPHP\Debug\Backtrace;
 use Hubbitus\HuPHP\System\OutputType;
 
+use Hubbitus\HuPHP\Vars\OutExtraDataBacktrace;
 use PHPUnit\Framework\TestCase;
 use Hubbitus\HuPHP\Debug\HuError;
 use Hubbitus\HuPHP\Debug\HuErrorSettings;
@@ -469,8 +471,8 @@ class HuErrorTest extends TestCase {
 	* Test formatField with OutExtraData instance.
 	**/
 	public function testFormatFieldWithOutExtraData(): void {
-		$bt = new \Hubbitus\HuPHP\Debug\Backtrace();
-		$extraData = new \Hubbitus\HuPHP\Vars\OutExtraDataBacktrace($bt);
+		$bt = new Backtrace();
+		$extraData = new OutExtraDataBacktrace($bt);
 		$this->error->extraField = $extraData;
 
 		$formatted = $this->error->formatField('extraField');
@@ -484,7 +486,7 @@ class HuErrorTest extends TestCase {
 	* Test formatField with Backtrace instance.
 	**/
 	public function testFormatFieldWithBacktrace(): void {
-		$bt = new \Hubbitus\HuPHP\Debug\Backtrace();
+		$bt = new Backtrace();
 		$this->error->btField = $bt;
 
 		$formatted = $this->error->formatField('btField');

--- a/tests/Debug/HuErrorTest.php
+++ b/tests/Debug/HuErrorTest.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Debug;
 use Hubbitus\HuPHP\Debug\Backtrace;
-use Hubbitus\HuPHP\System\OutputType;
+use Hubbitus\HuPHP\Debug\HuError;
 
+use Hubbitus\HuPHP\Debug\HuErrorSettings;
+use Hubbitus\HuPHP\System\OutputType;
 use Hubbitus\HuPHP\Vars\OutExtraDataBacktrace;
 use PHPUnit\Framework\TestCase;
-use Hubbitus\HuPHP\Debug\HuError;
-use Hubbitus\HuPHP\Debug\HuErrorSettings;
 
 /**
 * @covers \Hubbitus\HuPHP\Debug\HuError

--- a/tests/Debug/HuFormatTest.php
+++ b/tests/Debug/HuFormatTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Debug;
 
+use Hubbitus\HuPHP\Debug\Backtrace;
 use Hubbitus\HuPHP\Debug\HuFormat;
 use Hubbitus\HuPHP\Debug\HuFormatException;
 use PHPUnit\Framework\TestCase;
@@ -305,7 +306,7 @@ class HuFormatTest extends TestCase {
 	* Test modifier 'v' with Backtrace object.
 	**/
 	public function testModifierVWithBacktrace(): void {
-		$bt = new \Hubbitus\HuPHP\Debug\Backtrace();
+		$bt = new Backtrace();
 		$format = new HuFormat(['v:::'], $bt);
 		$result = $format->getString();
 		$this->assertStringContainsString('Backtrace', $result);

--- a/tests/Debug/HuFormatTest.php
+++ b/tests/Debug/HuFormatTest.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 namespace Hubbitus\Tests\HuPHP\Debug;
 
 use Hubbitus\HuPHP\Debug\Backtrace;
+use Hubbitus\HuPHP\Debug\HuError;
 use Hubbitus\HuPHP\Debug\HuFormat;
 use Hubbitus\HuPHP\Debug\HuFormatException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+use Hubbitus\HuPHP\Vars\OutExtraDataBacktrace;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
 * @covers \Hubbitus\HuPHP\Debug\HuFormat
 * @covers \Hubbitus\HuPHP\Debug\HuFormatException
 **/
-#[\PHPUnit\Framework\Attributes\CoversClass(\Hubbitus\HuPHP\Debug\HuFormat::class)]
+#[CoversClass(HuFormat::class)]
 class HuFormatTest extends TestCase {
 	/**
 	* Test constructor creates instance.
@@ -129,7 +134,7 @@ class HuFormatTest extends TestCase {
 	public function testFormatExtendsHuError(): void {
 		$format = new HuFormat();
 		$this->assertInstanceOf(HuFormat::class, $format);
-		$this->assertInstanceOf(\Hubbitus\HuPHP\Debug\HuError::class, $format);
+		$this->assertInstanceOf(HuError::class, $format);
 	}
 
 	/**
@@ -138,7 +143,7 @@ class HuFormatTest extends TestCase {
 	public function testFormatExceptionExtendsVariableException(): void {
 		$exception = new HuFormatException('test message');
 		$this->assertInstanceOf(HuFormatException::class, $exception);
-		$this->assertInstanceOf(\Hubbitus\HuPHP\Exceptions\Variables\VariableException::class, $exception);
+		$this->assertInstanceOf(VariableException::class, $exception);
 	}
 
 	/**
@@ -317,7 +322,7 @@ class HuFormatTest extends TestCase {
 	**/
 	public function testModifierVWithOutExtraDataBacktrace(): void {
 		$data = ['test' => 'value'];
-		$btData = new \Hubbitus\HuPHP\Vars\OutExtraDataBacktrace($data);
+		$btData = new OutExtraDataBacktrace($data);
 		$format = new HuFormat(['v:::'], $btData);
 		$result = $format->getString();
 		// OutExtraDataBacktrace has special handling in modifier 'v'
@@ -394,7 +399,7 @@ class HuFormatTest extends TestCase {
 	* Test modifier 'A' - all modifier with Backtrace.
 	**/
 	public function testModifierAWithBacktrace(): void {
-		$bt = new \Hubbitus\HuPHP\Debug\Backtrace();
+		$bt = new Backtrace();
 		$format = new HuFormat(['A:::'], $bt);
 		$result = $format->getString();
 		$this->assertStringContainsString('Backtrace', $result);
@@ -405,7 +410,7 @@ class HuFormatTest extends TestCase {
 	**/
 	public function testModifierAWithOutExtraDataBacktrace(): void {
 		$data = ['test' => 'value'];
-		$btData = new \Hubbitus\HuPHP\Vars\OutExtraDataBacktrace($data);
+		$btData = new OutExtraDataBacktrace($data);
 		$format = new HuFormat(['A:::'], $btData);
 		$this->assertStringContainsString('OutExtraDataBacktrace', $format->getString());
 	}
@@ -481,7 +486,7 @@ class HuFormatTest extends TestCase {
 	**/
 	public function testChangeModsStrUnknownModifier(): void {
 		$format = new HuFormat();
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException::class);
+		$this->expectException(VariableRangeException::class);
 		$format->changeModsStr('+x');
 	}
 
@@ -490,7 +495,7 @@ class HuFormatTest extends TestCase {
 	**/
 	public function testChangeModsStrOperatorWithoutModifier(): void {
 		$format = new HuFormat();
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException::class);
+		$this->expectException(VariableRangeException::class);
 		$format->changeModsStr('+');
 	}
 
@@ -692,7 +697,7 @@ class HuFormatTest extends TestCase {
 	**/
 	public function testChangeModsStrOperatorAtEnd(): void {
 		$format = new HuFormat();
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException::class);
+		$this->expectException(VariableRangeException::class);
 		$format->changeModsStr('+v-');
 	}
 
@@ -710,7 +715,7 @@ class HuFormatTest extends TestCase {
 		$prop->setAccessible(true);
 		$prop->setValue($format, 'x');
 
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException::class);
+		$this->expectException(VariableRangeException::class);
 		$method->invoke($format);
 	}
 
@@ -914,7 +919,7 @@ class HuFormatTest extends TestCase {
 	**/
 	public function testChangeModsStrUnknownOperator(): void {
 		$format = new HuFormat();
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException::class);
+		$this->expectException(VariableRangeException::class);
 		$this->expectExceptionMessage('Unknown modifier');
 		$format->changeModsStr('?v');
 	}

--- a/tests/Debug/HuLOGSettingsTest.php
+++ b/tests/Debug/HuLOGSettingsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Hubbitus\HuPHP\Tests\Debug;
 
 use Hubbitus\HuPHP\Debug\HuLOGSettings;
+use Hubbitus\HuPHP\Vars\Settings\Settings;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -75,7 +76,7 @@ class HuLOGSettingsTest extends TestCase {
 
 	public function testExtendsSettings(): void {
 		$settings = new HuLOGSettings();
-		$this->assertInstanceOf(\Hubbitus\HuPHP\Vars\Settings\Settings::class, $settings);
+		$this->assertInstanceOf(Settings::class, $settings);
 	}
 
 	public function testHasLengthMethod(): void {

--- a/tests/Debug/HuLOGSimpleTestFormatterTest.php
+++ b/tests/Debug/HuLOGSimpleTestFormatterTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Debug;
-use Hubbitus\HuPHP\System\OutputType;
 
 use Hubbitus\HuPHP\Debug\HuLOGSimpleTestFormatter;
 use Hubbitus\HuPHP\Debug\HuLOGText;

--- a/tests/Debug/HuLOGTest.php
+++ b/tests/Debug/HuLOGTest.php
@@ -2,11 +2,12 @@
 declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Debug;
-use Hubbitus\HuPHP\System\OutputType;
-
 use Hubbitus\HuPHP\Debug\HuLOG;
+
 use Hubbitus\HuPHP\Debug\HuLOGSettings;
 use Hubbitus\HuPHP\Debug\HuLOGSimpleTestFormatter;
+use Hubbitus\HuPHP\Debug\HuLOGText;
+use Hubbitus\HuPHP\System\OutputType;
 use Hubbitus\HuPHP\Vars\NullClass;
 use PHPUnit\Framework\TestCase;
 
@@ -78,7 +79,7 @@ class HuLOGTest extends TestCase {
 		$property->setAccessible(true);
 		$value = $property->getValue($log);
 
-		$this->assertInstanceOf(\Hubbitus\HuPHP\Debug\HuLOGText::class, $value);
+		$this->assertInstanceOf(HuLOGText::class, $value);
 	}
 
 	public function testLastLogTimeIsNullInitially(): void {

--- a/tests/Debug/HuLOGTextFormatterTest.php
+++ b/tests/Debug/HuLOGTextFormatterTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Debug;
-use Hubbitus\HuPHP\System\OutputType;
 
 use Hubbitus\HuPHP\Debug\HuLOGText;
 use Hubbitus\HuPHP\Debug\HuLOGTextFormatter;

--- a/tests/Debug/HuLOGTextSettingsTest.php
+++ b/tests/Debug/HuLOGTextSettingsTest.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Debug;
 
-use Hubbitus\HuPHP\Debug\HuLOGTextSettings;
 use Hubbitus\HuPHP\Debug\HuErrorSettings;
-use PHPUnit\Framework\TestCase;
+use Hubbitus\HuPHP\Debug\HuLOGTextSettings;
 use Hubbitus\HuPHP\System\OutputType;
+use PHPUnit\Framework\TestCase;
 
 /**
 * @covers \Hubbitus\HuPHP\Debug\HuLOGTextSettings

--- a/tests/Debug/HuLOGTextTest.php
+++ b/tests/Debug/HuLOGTextTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Debug;
-use Hubbitus\HuPHP\System\OutputType;
 
 use Hubbitus\HuPHP\Debug\HuLOGText;
 use Hubbitus\HuPHP\Debug\HuLOGTextSettings;

--- a/tests/Debug/TokenizerTest.php
+++ b/tests/Debug/TokenizerTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Debug;
 
-use Hubbitus\HuPHP\Debug\Tokenizer;
 use Hubbitus\HuPHP\Debug\BacktraceNode;
+use Hubbitus\HuPHP\Debug\Tokenizer;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Exceptions/Classes/ClassMethodExceptionTest.php
+++ b/tests/Exceptions/Classes/ClassMethodExceptionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Exceptions\Classes;
 
+use Hubbitus\HuPHP\Exceptions\Classes\ClassException;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassMethodException;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ class ClassMethodExceptionTest extends TestCase {
 		$exception = new ClassMethodException();
 
 		$this->assertInstanceOf(ClassMethodException::class, $exception);
-		$this->assertInstanceOf(\Hubbitus\HuPHP\Exceptions\Classes\ClassException::class, $exception);
+		$this->assertInstanceOf(ClassException::class, $exception);
 	}
 
 	public function testConstructorWithMessage(): void {

--- a/tests/Exceptions/ExceptionHierarchyTest.php
+++ b/tests/Exceptions/ExceptionHierarchyTest.php
@@ -4,21 +4,21 @@ declare(strict_types=1);
 namespace Hubbitus\Tests\HuPHP\Exceptions;
 
 use Hubbitus\HuPHP\Exceptions\BaseException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableReadOnlyException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassException;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassMethodException;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassNotExistsException;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassPropertyNotExistsException;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassUnknownException;
 use Hubbitus\HuPHP\Exceptions\Filesystem\FileException;
+use Hubbitus\HuPHP\Exceptions\NotImplementedException;
 use Hubbitus\HuPHP\Exceptions\ProcessException;
 use Hubbitus\HuPHP\Exceptions\SerializeException;
 use Hubbitus\HuPHP\Exceptions\SessionException;
-use Hubbitus\HuPHP\Exceptions\NotImplementedException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableReadOnlyException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -90,7 +90,7 @@ class ExceptionHierarchyTest extends TestCase {
 	public function testVariableEmptyExceptionExtendsVariableException(): void {
 		// VariableEmptyException extends VariableRequiredException which requires Backtrace
 		// We test the class hierarchy by checking reflection
-		$reflection = new \ReflectionClass(\Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException::class);
+		$reflection = new \ReflectionClass(VariableEmptyException::class);
 
 		$this->assertTrue($reflection->isSubclassOf(VariableException::class));
 		$this->assertTrue($reflection->isSubclassOf(BaseException::class));

--- a/tests/Exceptions/HuFormatExceptionTest.php
+++ b/tests/Exceptions/HuFormatExceptionTest.php
@@ -1,15 +1,15 @@
 <?php
 declare(strict_types=1);
 
-use PHPUnit\Framework\TestCase;
 use Hubbitus\HuPHP\Debug\HuFormatException;
+use PHPUnit\Framework\TestCase;
 
 /**
 * Class HuFormatExceptionTest.
 **/
 class HuFormatExceptionTest extends TestCase {
 	public function testExceptionClass(): void {
-		$this->assertInstanceOf(\Exception::class, new HuFormatException('Test message'));
+		$this->assertInstanceOf(Exception::class, new HuFormatException('Test message'));
 	}
 
 	public function testExceptionMessage(): void {

--- a/tests/Exceptions/Variables/VariableEmptyExceptionTest.php
+++ b/tests/Exceptions/Variables/VariableEmptyExceptionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Exceptions\Variables;
 
+use Hubbitus\HuPHP\Debug\Backtrace;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
 use PHPUnit\Framework\TestCase;
 
@@ -11,20 +12,20 @@ use PHPUnit\Framework\TestCase;
 **/
 class VariableEmptyExceptionTest extends TestCase {
 	public function testConstructorWithNoArguments(): void {
-		$exception = new VariableEmptyException(new \Hubbitus\HuPHP\Debug\Backtrace(), );
+		$exception = new VariableEmptyException(new Backtrace(), );
 
 		$this->assertInstanceOf(VariableEmptyException::class, $exception);
 	}
 
 	public function testConstructorWithMessage(): void {
-		$exception = new VariableEmptyException(new \Hubbitus\HuPHP\Debug\Backtrace(), null, 'Variable is empty');
+		$exception = new VariableEmptyException(new Backtrace(), null, 'Variable is empty');
 
 		$this->assertInstanceOf(VariableEmptyException::class, $exception);
 		$this->assertEquals('Variable is empty', $exception->getMessage());
 	}
 
 	public function testIsThrowable(): void {
-		$exception = new VariableEmptyException(new \Hubbitus\HuPHP\Debug\Backtrace(), );
+		$exception = new VariableEmptyException(new Backtrace(), );
 
 		$this->assertInstanceOf(\Throwable::class, $exception);
 	}
@@ -32,6 +33,6 @@ class VariableEmptyExceptionTest extends TestCase {
 	public function testExceptionCanBeThrown(): void {
 		$this->expectException(VariableEmptyException::class);
 
-		throw new VariableEmptyException(new \Hubbitus\HuPHP\Debug\Backtrace(), null, 'Variable is empty');
+		throw new VariableEmptyException(new Backtrace(), null, 'Variable is empty');
 	}
 }

--- a/tests/Exceptions/Variables/VariableExceptionsTest.php
+++ b/tests/Exceptions/Variables/VariableExceptionsTest.php
@@ -3,12 +3,13 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Exceptions\Variables;
 
+use Hubbitus\HuPHP\Debug\Backtrace;
+use Hubbitus\HuPHP\Exceptions\BaseException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableArrayInconsistentException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableReadOnlyException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableArrayInconsistentException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException;
-use Hubbitus\HuPHP\Exceptions\BaseException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -146,17 +147,17 @@ class VariableExceptionsTest extends TestCase {
 	}
 
 	public function testVariableIsNullExceptionInstantiation(): void {
-		$exception = new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Variable is null');
+		$exception = new VariableIsNullException(new Backtrace(), 'Variable is null');
 		$this->assertInstanceOf(VariableIsNullException::class, $exception);
 	}
 
 	public function testVariableIsNullExceptionMessage(): void {
-		$exception = new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), null, 'Required variable is null');
+		$exception = new VariableIsNullException(new Backtrace(), null, 'Required variable is null');
 		$this->assertEquals('Required variable is null', $exception->getMessage());
 	}
 
 	public function testVariableIsNullExceptionCode(): void {
-		$exception = new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Null value', null, 400);
+		$exception = new VariableIsNullException(new Backtrace(), 'Null value', null, 400);
 		$this->assertEquals(400, $exception->getCode());
 	}
 
@@ -164,11 +165,11 @@ class VariableExceptionsTest extends TestCase {
 		$this->expectException(VariableIsNullException::class);
 		$this->expectExceptionMessage('Variable cannot be null');
 
-		throw new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), null, 'Variable cannot be null');
+		throw new VariableIsNullException(new Backtrace(), null, 'Variable cannot be null');
 	}
 
 	public function testVariableIsNullExceptionInheritance(): void {
-		$exception = new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Error');
+		$exception = new VariableIsNullException(new Backtrace(), 'Error');
 		$this->assertInstanceOf(\Throwable::class, $exception);
 		$this->assertInstanceOf(\Exception::class, $exception);
 	}
@@ -179,7 +180,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -193,7 +194,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -207,7 +208,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test message 2'),
 			new VariableReadOnlyException('Test message 3'),
 			new VariableArrayInconsistentException('Test message 4'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), null, 'Test message 5')
+			new VariableIsNullException(new Backtrace(), null, 'Test message 5')
 		];
 
 		foreach ($exceptions as $index => $exception) {
@@ -221,7 +222,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test', 2),
 			new VariableReadOnlyException('Test', 3),
 			new VariableArrayInconsistentException('Test', 4),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test', null, 5)
+			new VariableIsNullException(new Backtrace(), 'Test', null, 5)
 		];
 
 		$codes = [1, 2, 3, 4, 5];
@@ -236,7 +237,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -251,7 +252,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -266,7 +267,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -280,7 +281,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -294,7 +295,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -309,7 +310,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -324,7 +325,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -338,7 +339,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -352,7 +353,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -373,7 +374,7 @@ class VariableExceptionsTest extends TestCase {
 		$exception4 = new VariableArrayInconsistentException('Test');
 		$this->assertEquals('Hubbitus\HuPHP\Exceptions\Variables\VariableArrayInconsistentException', \get_class($exception4));
 
-		$exception5 = new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test');
+		$exception5 = new VariableIsNullException(new Backtrace(), 'Test');
 		$this->assertEquals('Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException', \get_class($exception5));
 	}
 
@@ -406,7 +407,7 @@ class VariableExceptionsTest extends TestCase {
 	}
 
 	public function testNullExceptionInheritanceChain(): void {
-		$exception = new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Error');
+		$exception = new VariableIsNullException(new Backtrace(), 'Error');
 
 		$this->assertInstanceOf(VariableIsNullException::class, $exception);
 		$this->assertInstanceOf(\Exception::class, $exception);
@@ -457,7 +458,7 @@ class VariableExceptionsTest extends TestCase {
 			new VariableRangeException('Test'),
 			new VariableReadOnlyException('Test'),
 			new VariableArrayInconsistentException('Test'),
-			new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), 'Test')
+			new VariableIsNullException(new Backtrace(), 'Test')
 		];
 
 		foreach ($exceptions as $exception) {
@@ -567,7 +568,7 @@ class VariableExceptionsTest extends TestCase {
 	}
 
 	public function testNullExceptionSpecificMessage(): void {
-		$exception = new VariableIsNullException(new \Hubbitus\HuPHP\Debug\Backtrace(), null, 'Required parameter $id is null');
+		$exception = new VariableIsNullException(new Backtrace(), null, 'Required parameter $id is null');
 		$this->assertStringContainsString('null', \strtolower($exception->getMessage()));
 	}
 }

--- a/tests/Exceptions/Variables/VariableIsNullExceptionTest.php
+++ b/tests/Exceptions/Variables/VariableIsNullExceptionTest.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Exceptions\Variables;
 
+use Hubbitus\HuPHP\Debug\Backtrace;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
-use Hubbitus\HuPHP\Debug\Backtrace;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Exceptions/Variables/VariableRequiredExceptionTest.php
+++ b/tests/Exceptions/Variables/VariableRequiredExceptionTest.php
@@ -3,16 +3,17 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Exceptions\Variables;
 
+use Hubbitus\HuPHP\Debug\Backtrace;
 use Hubbitus\HuPHP\Debug\Tokenizer;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
-use Hubbitus\HuPHP\Debug\Backtrace;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
 * @covers \Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException
 **/
-#[\PHPUnit\Framework\Attributes\CoversClass(\Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException::class)]
+#[CoversClass(VariableRequiredException::class)]
 class VariableRequiredExceptionTest extends TestCase {
 	public function testConstructorWithBacktrace(): void {
 		$backtrace = new Backtrace();

--- a/tests/Filesystem/FileBaseAdditionalTest.php
+++ b/tests/Filesystem/FileBaseAdditionalTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Filesystem;
 
-use Hubbitus\HuPHP\Filesystem\FileBase;
 use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotReadableException;
+use Hubbitus\HuPHP\Filesystem\FileBase;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Filesystem/FileBaseTest.php
+++ b/tests/Filesystem/FileBaseTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Filesystem;
 
+use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotExistsException;
+use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotReadableException;
 use Hubbitus\HuPHP\Filesystem\FileBase;
 use PHPUnit\Framework\TestCase;
 
@@ -147,7 +149,7 @@ class FileBaseTest extends TestCase {
 	}
 
 	public function testWriteContentToNonExistingDirectory(): void {
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Filesystem\FileNotExistsException::class);
+		$this->expectException(FileNotExistsException::class);
 		$file = new FileBase('/nonexistent/dir/file.txt');
 		$file->setContentFromString('test');
 		$file->writeContent();
@@ -169,7 +171,7 @@ class FileBaseTest extends TestCase {
 
 		// File exists and is readable, but we pass false to simulate unknown error
 		// This should throw FileNotReadableException with "Unknown error" message
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Filesystem\FileNotReadableException::class);
+		$this->expectException(FileNotReadableException::class);
 		$this->expectExceptionMessage('Unknown error operate on file');
 		$method->invoke($file, false);
 	}

--- a/tests/Filesystem/FileBaseUnknownErrorTest.php
+++ b/tests/Filesystem/FileBaseUnknownErrorTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Filesystem;
 
-use Hubbitus\HuPHP\Filesystem\FileBase;
 use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotExistsException;
+use Hubbitus\HuPHP\Filesystem\FileBase;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Filesystem/FileInMemoryAdditionalTest.php
+++ b/tests/Filesystem/FileInMemoryAdditionalTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Filesystem;
 
-use Hubbitus\HuPHP\Filesystem\FileInMemory;
 use Hubbitus\HuPHP\Exceptions\Filesystem\FileNotExistsException;
+use Hubbitus\HuPHP\Filesystem\FileInMemory;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Filesystem/FileInMemoryTest.php
+++ b/tests/Filesystem/FileInMemoryTest.php
@@ -929,6 +929,13 @@ class FileInMemoryTest extends TestCase {
 	}
 
 	public function testEnconvIntegration(): void {
+		// Check if enconv is available
+		\exec('command -v enconv', $output, $return_var);
+		if ($return_var !== 0) {
+			// enconv not available - skip test
+			$this->markTestSkipped('enconv command not available');
+		}
+
 		$testFile = $this->testDir . '/test_enconv.txt';
 		$koi8rContent = "\xf2\xd5\xd3\xd3\xcb\xc9\xca\x20\xd4\xc5\xd3\xd4\x20\xc4\xcc\xd1\x20\xd0\xd2\xc9\xcd\xc5\xd2\xc1";
 

--- a/tests/Filesystem/FileInMemoryTest.php
+++ b/tests/Filesystem/FileInMemoryTest.php
@@ -781,6 +781,34 @@ class FileInMemoryTest extends TestCase {
 		}
 	}
 
+	public function testEnconvThrowsExceptionWhenExecutableNotFoundViaReflection(): void {
+		// Test that enconv() throws proper exception when executable is not found
+		// by changing the ENCONV_EXECUTABLE property to a non-existent command
+		$testFile = $this->testDir . '/test_enconv_notfound.txt';
+		\file_put_contents($testFile, 'test content');
+
+		try {
+			$file = new FileInMemory($testFile);
+			$file->loadContent();
+
+			// Change the ENCONV_EXECUTABLE property to a non-existent command
+			$file->ENCONV_EXECUTABLE = 'nonexistent_enconv_command_xyz';
+
+			// This should throw ProcessException with "command not found" message
+			$file->enconv('russian', 'UTF-8');
+			$this->fail('Expected ProcessException to be thrown');
+		} catch (ProcessException $e) {
+			// Verify it's the "command not found" exception (exit code 127)
+			// The state might be null if exception is thrown from different location
+			if ($e->state !== null) {
+				$this->assertEquals(127, $e->state->exit_code);
+			}
+			$this->assertStringContainsString('command not found', $e->getMessage());
+		} finally {
+			\unlink($testFile);
+		}
+	}
+
 	public function testIconv(): void {
 		// Test iconv() method for charset conversion
 		$testFile = $this->testDir . '/test_iconv.txt';

--- a/tests/Filesystem/FileInMemoryTest.php
+++ b/tests/Filesystem/FileInMemoryTest.php
@@ -6,6 +6,7 @@ namespace Hubbitus\HuPHP\Tests\Filesystem;
 
 use Hubbitus\HuPHP\Filesystem\FileInMemory;
 use PHPUnit\Framework\TestCase;
+use Hubbitus\HuPHP\Exceptions\ProcessException;
 
 /**
 * Test for FileInMemory class.
@@ -54,7 +55,7 @@ class FileInMemoryTest extends TestCase {
 
 	public function testClassExtendsFileBase(): void {
 		$file = new FileInMemory($this->testFile);
-		$this->assertInstanceOf('Hubbitus\\HuPHP\\Filesystem\\FileBase', $file);
+		$this->assertInstanceOf('Hubbitus\HuPHP\Filesystem\FileBase', $file);
 	}
 
 	public function testLoadContent(): void {
@@ -123,8 +124,8 @@ class FileInMemoryTest extends TestCase {
 	public function testSetLineSep(): void {
 		$file = new FileInMemory($this->testFile);
 		$file->loadContent();
-		$file->setLineSep("\r\n");
-		$this->assertEquals("\r\n", $file->getLineSep());
+		$file->setLineSep("\n");
+		$this->assertEquals("\n", $file->getLineSep());
 	}
 
 	public function testGetBLOB(): void {
@@ -152,6 +153,31 @@ class FileInMemoryTest extends TestCase {
 
 		// Verify content was written
 		$this->assertEquals("Modified content", \file_get_contents($this->testFile));
+	}
+
+	public function testWriteContentWithCustomImplodeAndLineSep(): void {
+		// Test writeContent() with custom implodeWith and updateLineSep parameters
+		$testFile = $this->testDir . '/write_custom.txt';
+
+		// First create the file
+		\file_put_contents($testFile, "Line 1\nLine 2\nLine 3\n");
+
+		// Create file in memory with path
+		$file = new FileInMemory($testFile);
+		$file->loadContent();
+
+		// Force lineContent to be populated by calling getLines()
+		$file->getLines();
+
+		// Write with custom line separator - updateLineSep=true should update _lineSep to "\r\n"
+		$count = $file->writeContent(null, null, "\r\n", true);
+
+		// Verify file was written
+		$this->assertGreaterThan(0, $count);
+
+		// Verify file was written with new line separator
+		$content = \file_get_contents($testFile);
+		$this->assertStringContainsString("\r\n", $content);
 	}
 
 	public function testGetLineByOffset(): void {
@@ -226,13 +252,13 @@ class FileInMemoryTest extends TestCase {
 
 	public function testMultipleLineEndings(): void {
 		$multiFile = $this->testDir . '/multi.txt';
-		\file_put_contents($multiFile, "Line 1\r\nLine 2\r\nLine 3\r\n");
+		\file_put_contents($multiFile, "Line 1\nLine 2\nLine 3\n");
 
 		$file = new FileInMemory($multiFile);
 		$file->loadContent();
 		$lines = $file->getLines();
-		// With \r\n line endings, the regex may split differently
-		// Just verify we get some lines back
+		// The regex may split differently with line endings.
+		// Just verify we get some lines back.
 		$this->assertGreaterThan(0, \count($lines));
 
 		\unlink($multiFile);
@@ -676,23 +702,6 @@ class FileInMemoryTest extends TestCase {
 		}
 	}
 
-	public function testGetLinesWithoutLoadThrowsException(): void {
-		// Test that getLines() throws exception when content is not loaded
-		// This indirectly tests the private checkLoad() method
-		$testFile = $this->testDir . '/test.txt';
-		\file_put_contents($testFile, 'test content');
-
-		try {
-			$file = new FileInMemory($testFile);
-			// Don't call loadContent() - should throw exception
-
-			$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException::class);
-			$file->getLines();
-		} finally {
-			\unlink($testFile);
-		}
-	}
-
 	public function testEnconvMethodExists(): void {
 		// Test that enconv() method exists
 		$testFile = $this->testDir . '/test.txt';
@@ -723,9 +732,73 @@ class FileInMemoryTest extends TestCase {
 			$result = $file->enconv('russian', 'UTF-8');
 			$this->assertSame($file, $result);
 		} catch (\Throwable $e) {
-			// enconv shell command may not be available
+			// enconv shell command may not available or other error
 			// This is acceptable - we're testing the method exists and returns self
 			$this->assertStringContainsString('enconv', $e->getMessage());
+		} finally {
+			\unlink($testFile);
+		}
+	}
+
+	public function testEnconvThrowsExceptionWhenCommandNotFound(): void {
+		// Test that enconv() throws exception when command is not found
+		// We test this by verifying ProcessState handling in enconv method
+
+		// First verify that calling with non-existent command throws ProcessException
+		$state = new \Hubbitus\HuPHP\System\ProcessState();
+		$state->CMD = 'nonexistent_command_that_does_not_exist';
+		$state->writeData = 'test';
+
+		try {
+			\Hubbitus\HuPHP\System\Process::exec($state);
+			$this->fail('Expected ProcessException to be thrown');
+		} catch (ProcessException $e) {
+			// Verify the exception contains exit code 127
+			$this->assertStringContainsString('127', $e->getMessage());
+		}
+
+		// Now test that FileInMemory::enconv properly handles enconv failure
+		// by checking it throws ProcessException when enconv fails
+		$testFile = $this->testDir . '/test_enconv_fail.txt';
+		\file_put_contents($testFile, 'test content');
+
+		try {
+			$file = new FileInMemory($testFile);
+			$file->loadContent();
+
+			// enconv with invalid parameters should fail
+			// This tests the error handling path (non-127 exit codes)
+			$file->enconv('invalid_lang_12345', 'INVALID_ENC');
+		} catch (ProcessException $e) {
+			// Expected - enconv failed with some error
+			$this->assertStringContainsString('enconv', $e->getMessage());
+		} finally {
+			\unlink($testFile);
+		}
+	}
+
+	public function testIconv(): void {
+		// Test iconv() method for charset conversion
+		$testFile = $this->testDir . '/test_iconv.txt';
+		// UTF-8 encoded content
+		$content = 'Привет Мир';
+		\file_put_contents($testFile, $content);
+
+		try {
+			$file = new FileInMemory($testFile);
+			$file->loadContent();
+
+			// Convert from UTF-8 to Windows-1251 and back to UTF-8
+			$result = $file->iconv('UTF-8', 'Windows-1251');
+			$this->assertSame($file, $result);
+
+			// Verify content was converted
+			$windows1251Content = $file->getBLOB();
+			$this->assertIsString($windows1251Content);
+
+			// Convert back to UTF-8
+			$file->iconv('Windows-1251', 'UTF-8');
+			$this->assertEquals($content, $file->getBLOB());
 		} finally {
 			\unlink($testFile);
 		}
@@ -804,7 +877,6 @@ class FileInMemoryTest extends TestCase {
 	}
 
 	public function testExplodeLinesWithEmptyContent(): void {
-		// Test that explodeLines handles empty content gracefully
 		$testFile = $this->testDir . '/test_explode_empty.txt';
 		\file_put_contents($testFile, '');
 
@@ -812,7 +884,6 @@ class FileInMemoryTest extends TestCase {
 			$file = new FileInMemory($testFile);
 			$file->loadContent();
 
-			// Get lines from empty file
 			$lines = $file->getLines();
 			$this->assertIsArray($lines);
 			$this->assertEmpty($lines);
@@ -822,15 +893,11 @@ class FileInMemoryTest extends TestCase {
 	}
 
 	public function testExplodeLinesWithNullContent(): void {
-		// Test explodeLines when content is null (not loaded yet)
 		$testFile = $this->testDir . '/test_explode_null.txt';
 		\file_put_contents($testFile, 'test content');
 
 		try {
 			$file = new FileInMemory($testFile);
-			// Don't call loadContent - content is null
-
-			// getLineAt should handle null content
 			$line = $file->getLineAt(0);
 			$this->assertIsString($line);
 			$this->assertEquals('test content', $line);
@@ -839,14 +906,26 @@ class FileInMemoryTest extends TestCase {
 		}
 	}
 
-	public function testEnconvIntegration(): void {
-		\exec('command -v enconv', $output, $return_var);
-		if ($return_var !== 0) {
-			$this->markTestSkipped('`enconv` command not found, skipping integration test.');
-		}
+	public function testGetLinesAfterSetContent(): void {
+		$file = new FileInMemory();
+		$file->setContentFromString("line1\nline2");
+		$lines = $file->getLines();
+		$file->clearPendingWrite(); // Prevent writing on destruct
+		$this->assertCount(2, $lines);
+	}
 
+	public function testGetLinesWithoutContentThrowsException(): void {
+		// Test that getLines() throws exception when content is not loaded
+		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException::class);
+
+		$file = new FileInMemory();
+		// Don't set or load content - content will be null
+		// getLines() should call checkLoad() which throws exception
+		$file->getLines();
+	}
+
+	public function testEnconvIntegration(): void {
 		$testFile = $this->testDir . '/test_enconv.txt';
-		// Content in KOI8-R: "Русский тест для примера"
 		$koi8rContent = "\xf2\xd5\xd3\xd3\xcb\xc9\xca\x20\xd4\xc5\xd3\xd4\x20\xc4\xcc\xd1\x20\xd0\xd2\xc9\xcd\xc5\xd2\xc1";
 
 		\file_put_contents($testFile, $koi8rContent);

--- a/tests/Filesystem/FileInMemoryTest.php
+++ b/tests/Filesystem/FileInMemoryTest.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Filesystem;
 
-use Hubbitus\HuPHP\Filesystem\FileInMemory;
-use PHPUnit\Framework\TestCase;
 use Hubbitus\HuPHP\Exceptions\ProcessException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+use Hubbitus\HuPHP\Filesystem\FileInMemory;
+use Hubbitus\HuPHP\System\Process;
+use Hubbitus\HuPHP\System\ProcessState;
+use PHPUnit\Framework\TestCase;
 
 /**
 * Test for FileInMemory class.
@@ -198,7 +202,7 @@ class FileInMemoryTest extends TestCase {
 	}
 
 	public function testGetOffsetByLineThrowsException(): void {
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException::class);
+		$this->expectException(VariableRangeException::class);
 
 		$file = new FileInMemory($this->testFile);
 		$file->loadContent();
@@ -326,7 +330,7 @@ class FileInMemoryTest extends TestCase {
 		$file->loadContent();
 
 		// Offset beyond file size should throw exception
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException::class);
+		$this->expectException(VariableRangeException::class);
 		$file->getLineByOffset(9999999);
 	}
 
@@ -745,12 +749,12 @@ class FileInMemoryTest extends TestCase {
 		// We test this by verifying ProcessState handling in enconv method
 
 		// First verify that calling with non-existent command throws ProcessException
-		$state = new \Hubbitus\HuPHP\System\ProcessState();
+		$state = new ProcessState();
 		$state->CMD = 'nonexistent_command_that_does_not_exist';
 		$state->writeData = 'test';
 
 		try {
-			\Hubbitus\HuPHP\System\Process::exec($state);
+			Process::exec($state);
 			$this->fail('Expected ProcessException to be thrown');
 		} catch (ProcessException $e) {
 			// Verify the exception contains exit code 127
@@ -916,7 +920,7 @@ class FileInMemoryTest extends TestCase {
 
 	public function testGetLinesWithoutContentThrowsException(): void {
 		// Test that getLines() throws exception when content is not loaded
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException::class);
+		$this->expectException(VariableEmptyException::class);
 
 		$file = new FileInMemory();
 		// Don't set or load content - content will be null

--- a/tests/Macro/UnicodeTest.php
+++ b/tests/Macro/UnicodeTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Macro;
 
-use Hubbitus\HuPHP\Macro\Unicode;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
+use Hubbitus\HuPHP\Macro\Unicode;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Macro/VarsTest.php
+++ b/tests/Macro/VarsTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Macro;
 
-use Hubbitus\HuPHP\Macro\Vars;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableIsNullException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
+use Hubbitus\HuPHP\Macro\Vars;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/System/Console/HuGetoptCompleteTest.php
+++ b/tests/System/Console/HuGetoptCompleteTest.php
@@ -3,11 +3,12 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\System\Console;
 
-use PHPUnit\Framework\TestCase;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use Hubbitus\HuPHP\System\Console\HuGetopt;
 use Hubbitus\HuPHP\System\Console\HuGetoptOption;
 use Hubbitus\HuPHP\System\Console\HuGetoptSettings;
 use Hubbitus\HuPHP\Vars\HuArray;
+use PHPUnit\Framework\TestCase;
 
 /**
 * Complete coverage tests for HuGetopt, HuGetoptOption and HuGetoptSettings.
@@ -552,7 +553,7 @@ class HuGetoptCompleteTest extends TestCase {
 	* Test HuGetopt parseArgs when required option next is option (should throw exception).
 	**/
 	public function testHuGetoptParseArgsRequiredOptionNextIsOption(): void {
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException::class);
+		$this->expectException(VariableRequiredException::class);
 		$this->expectExceptionMessage('requires argument');
 
 		$opts = [
@@ -569,7 +570,7 @@ class HuGetoptCompleteTest extends TestCase {
 	* Test HuGetopt parseArgs when required option at end with no value.
 	**/
 	public function testHuGetoptParseArgsRequiredOptionAtEnd(): void {
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException::class);
+		$this->expectException(VariableRequiredException::class);
 		$this->expectExceptionMessage('requires argument');
 
 		$opts = [['f', 'file', ':']];

--- a/tests/System/Console/HuGetoptNewTest.php
+++ b/tests/System/Console/HuGetoptNewTest.php
@@ -3,8 +3,12 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\System\Console;
 
+use Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException;
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use Hubbitus\HuPHP\System\Console\HuGetopt;
+use Hubbitus\HuPHP\System\Console\HuGetoptOption;
 use Hubbitus\HuPHP\System\Console\HuGetoptSettings;
+use Hubbitus\HuPHP\Vars\HuArray;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -73,7 +77,7 @@ class HuGetoptNewTest extends TestCase {
 
 		$nonOpts = $getopt->getNonOpts();
 
-		$this->assertInstanceOf(\Hubbitus\HuPHP\Vars\HuArray::class, $nonOpts);
+		$this->assertInstanceOf(HuArray::class, $nonOpts);
 	}
 
 	public function testSetOptsReturnsReference(): void {
@@ -130,7 +134,7 @@ class HuGetoptNewTest extends TestCase {
 		$opt = $getopt->getOptByStr('v');
 
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$opt
 		);
 	}
@@ -143,7 +147,7 @@ class HuGetoptNewTest extends TestCase {
 		$opt = $getopt->get('v');
 
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$opt
 		);
 	}
@@ -157,7 +161,7 @@ class HuGetoptNewTest extends TestCase {
 		$opt = $getopt->getOptByStr('v');
 
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$opt
 		);
 	}
@@ -171,7 +175,7 @@ class HuGetoptNewTest extends TestCase {
 		$opt = $getopt->getOptByStr('verbose');
 
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$opt
 		);
 	}
@@ -185,7 +189,7 @@ class HuGetoptNewTest extends TestCase {
 		$opt = $getopt->getOptByStr('v', 's');
 
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$opt
 		);
 	}
@@ -199,7 +203,7 @@ class HuGetoptNewTest extends TestCase {
 		$opt = $getopt->getOptByStr('verbose', 'l');
 
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$opt
 		);
 	}
@@ -213,7 +217,7 @@ class HuGetoptNewTest extends TestCase {
 
 		$result = $getopt->getShortOpt('-v');
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$result
 		);
 	}
@@ -227,7 +231,7 @@ class HuGetoptNewTest extends TestCase {
 
 		$result = $getopt->getShortOpt('-f');
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$result
 		);
 	}
@@ -252,7 +256,7 @@ class HuGetoptNewTest extends TestCase {
 
 		$result = $getopt->getLongOpt('--verbose');
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$result
 		);
 	}
@@ -266,7 +270,7 @@ class HuGetoptNewTest extends TestCase {
 
 		$result = $getopt->getLongOpt('--file=test.txt');
 		$this->assertInstanceOf(
-			\Hubbitus\HuPHP\System\Console\HuGetoptOption::class,
+			HuGetoptOption::class,
 			$result
 		);
 	}
@@ -532,7 +536,7 @@ class HuGetoptNewTest extends TestCase {
 
 	public function testParseArgsWithDoubleColonModRequiresArgumentException(): void {
 		// : (required) - no argument should throw exception
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException::class);
+		$this->expectException(VariableRequiredException::class);
 		$this->expectExceptionMessage('requires argument');
 
 		$settings = new HuGetoptSettings();
@@ -630,7 +634,7 @@ class HuGetoptNewTest extends TestCase {
 	}
 
 	public function testReadPHPArgvThrowsExceptionWhenNoArgv(): void {
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableEmptyException::class);
+		$this->expectException(VariableEmptyException::class);
 
 		global $argv;
 		$originalArgv = $argv ?? null;

--- a/tests/System/Console/HuGetoptOptionTest.php
+++ b/tests/System/Console/HuGetoptOptionTest.php
@@ -5,6 +5,7 @@ namespace Hubbitus\HuPHP\Tests\System\Console;
 
 use Hubbitus\HuPHP\System\Console\HuGetoptOption;
 use Hubbitus\HuPHP\Vars\HuArray;
+use Hubbitus\HuPHP\Vars\Settings\SettingsCheck;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -114,7 +115,7 @@ class HuGetoptOptionTest extends TestCase {
 		$possibles = ['long' => 'l'];
 		$option = new HuGetoptOption($possibles);
 
-		$this->assertInstanceOf(\Hubbitus\HuPHP\Vars\Settings\SettingsCheck::class, $option);
+		$this->assertInstanceOf(SettingsCheck::class, $option);
 	}
 
 	public function testPropertyAccess(): void {

--- a/tests/System/Console/HuGetoptTest.php
+++ b/tests/System/Console/HuGetoptTest.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\System\Console;
 
+use Hubbitus\HuPHP\System\Console\HuGetopt;
 use Hubbitus\HuPHP\System\Console\HuGetoptOption;
+use Hubbitus\HuPHP\System\Console\HuGetoptSettings;
 use Hubbitus\HuPHP\Vars\HuArray;
 use PHPUnit\Framework\TestCase;
-use Hubbitus\HuPHP\System\Console\HuGetopt;
-use Hubbitus\HuPHP\System\Console\HuGetoptSettings;
 
 /**
 * @covers \Hubbitus\HuPHP\System\Console\HuGetopt

--- a/tests/System/OSTest.php
+++ b/tests/System/OSTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\System;
 
-use Hubbitus\HuPHP\System\OutputType;
-use Hubbitus\HuPHP\System\OS;
 use Hubbitus\HuPHP\Exceptions\HaltException;
+use Hubbitus\HuPHP\System\OS;
+use Hubbitus\HuPHP\System\OutputType;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/System/ProcessTest.php
+++ b/tests/System/ProcessTest.php
@@ -49,8 +49,9 @@ class ProcessTest extends TestCase {
 	public function testExec(): void {
 		$result = Process::exec('echo "test"');
 
-		$this->assertIsString($result);
-		$this->assertStringContainsString('test', $result);
+		$this->assertInstanceOf(ProcessState::class, $result);
+		$this->assertIsString($result->getResult());
+		$this->assertStringContainsString('test', $result->getResult());
 	}
 
 	public function testExecWithProcessState(): void {
@@ -59,30 +60,34 @@ class ProcessTest extends TestCase {
 
 		$result = Process::exec($state);
 
-		$this->assertIsString($result);
-		$this->assertStringContainsString('hello', $result);
+		$this->assertInstanceOf(ProcessState::class, $result);
+		$this->assertIsString($result->getResult());
+		$this->assertStringContainsString('hello', $result->getResult());
 	}
 
 	public function testExecWithCwd(): void {
 		$result = Process::exec('pwd', '/tmp');
 
-		$this->assertIsString($result);
-		$this->assertStringContainsString('/tmp', $result);
+		$this->assertInstanceOf(ProcessState::class, $result);
+		$this->assertIsString($result->getResult());
+		$this->assertStringContainsString('/tmp', $result->getResult());
 	}
 
 	public function testExecWithEnv(): void {
 		$result = Process::exec('echo $TEST_VAR', null, ['TEST_VAR' => 'custom_value']);
 
-		$this->assertIsString($result);
-		$this->assertStringContainsString('custom_value', $result);
+		$this->assertInstanceOf(ProcessState::class, $result);
+		$this->assertIsString($result->getResult());
+		$this->assertStringContainsString('custom_value', $result->getResult());
 	}
 
 	public function testExecWithWriteData(): void {
 		// Test with cat command which echoes input
 		$result = Process::exec('cat', null, null, 'test input');
 
-		$this->assertIsString($result);
-		$this->assertStringContainsString('test input', $result);
+		$this->assertInstanceOf(ProcessState::class, $result);
+		$this->assertIsString($result->getResult());
+		$this->assertStringContainsString('test input', $result->getResult());
 	}
 
 	public function testOpen(): void {
@@ -281,8 +286,9 @@ class ProcessTest extends TestCase {
 		// Test exec() with both cwd and env
 		$result = Process::exec('pwd', '/tmp', ['TEST' => 'value']);
 
-		$this->assertIsString($result);
-		$this->assertStringContainsString('/tmp', $result);
+		$this->assertInstanceOf(ProcessState::class, $result);
+		$this->assertIsString($result->getResult());
+		$this->assertStringContainsString('/tmp', $result->getResult());
 	}
 
 	public function testExecPreservesState(): void {
@@ -293,7 +299,8 @@ class ProcessTest extends TestCase {
 
 		$result = Process::exec($state);
 
-		$this->assertIsString($result);
+		$this->assertInstanceOf(ProcessState::class, $result);
+		$this->assertIsString($result->getResult());
 		$this->assertEquals('/tmp', $state->getCwd());
 	}
 

--- a/tests/System/ProcessTest.php
+++ b/tests/System/ProcessTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\System;
 
+use Hubbitus\HuPHP\Exceptions\ProcessException;
 use Hubbitus\HuPHP\System\Process;
 use Hubbitus\HuPHP\System\ProcessState;
-use Hubbitus\HuPHP\Exceptions\ProcessException;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Vars/HuConfigTest.php
+++ b/tests/Vars/HuConfigTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Vars;
 
-use Hubbitus\HuPHP\Vars\HuConfig;
-use Hubbitus\HuPHP\Vars\HuArray;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassPropertyNotExistsException;
+use Hubbitus\HuPHP\Vars\HuArray;
+use Hubbitus\HuPHP\Vars\HuConfig;
 use PHPUnit\Framework\TestCase;
 
 use function Hubbitus\HuPHP\Vars\CONF;

--- a/tests/Vars/OutExtraDataCommonTest.php
+++ b/tests/Vars/OutExtraDataCommonTest.php
@@ -5,9 +5,7 @@ namespace Hubbitus\Tests\HuPHP\Vars;
 use Hubbitus\HuPHP\System\OutputType;
 
 use Hubbitus\HuPHP\Vars\OutExtraDataCommon;
-use Hubbitus\HuPHP\System\OS;
 use PHPUnit\Framework\TestCase;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRangeException;
 
 class OutExtraDataCommonTest extends TestCase {
 	public function testConstructor(): void {

--- a/tests/Vars/OutExtraDataDOMnodeTest.php
+++ b/tests/Vars/OutExtraDataDOMnodeTest.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Vars;
-use Hubbitus\HuPHP\System\OutputType;
 
 use Hubbitus\HuPHP\Vars\OutExtraDataDOMnode;
 use PHPUnit\Framework\TestCase;

--- a/tests/Vars/Settings/SettingsCheckTest.php
+++ b/tests/Vars/Settings/SettingsCheckTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Vars\Settings;
 
-use Hubbitus\HuPHP\Vars\Settings\SettingsCheck;
 use Hubbitus\HuPHP\Exceptions\Classes\ClassPropertyNotExistsException;
+use Hubbitus\HuPHP\Vars\Settings\SettingsCheck;
 use PHPUnit\Framework\TestCase;
 
 class SettingsCheckTest extends TestCase {

--- a/tests/Vars/Settings/SettingsFilterTest.php
+++ b/tests/Vars/Settings/SettingsFilterTest.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Vars\Settings;
 
+use Hubbitus\HuPHP\Vars\Settings\Filters\SettingsFilterDefault;
+use Hubbitus\HuPHP\Vars\Settings\Filters\SettingsFilterIgnore;
 use Hubbitus\HuPHP\Vars\Settings\SettingsFilter;
 use Hubbitus\HuPHP\Vars\Settings\SettingsFilterBase;
-use Hubbitus\HuPHP\Vars\Settings\Filters\SettingsFilterIgnore;
-use Hubbitus\HuPHP\Vars\Settings\Filters\SettingsFilterDefault;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Vars/Settings/SettingsTest.php
+++ b/tests/Vars/Settings/SettingsTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Vars\Settings;
 
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use Hubbitus\HuPHP\Vars\Settings\Settings;
 use PHPUnit\Framework\TestCase;
 
@@ -38,7 +39,7 @@ class SettingsTest extends TestCase {
 
 	public function testSetSettingsArrayThrowsExceptionOnEmpty(): void {
 		$settings = new Settings();
-		$this->expectException(\Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException::class);
+		$this->expectException(VariableRequiredException::class);
 		$settings->setSettingsArray([]);
 	}
 

--- a/tests/Vars/SingleDefTest.bootstrap.php
+++ b/tests/Vars/SingleDefTest.bootstrap.php
@@ -8,8 +8,8 @@ function CONF(): object {
 			'Hubbitus\Tests\HuPHP\Vars\TestConfigClass' => ['config_arg1', 'config_arg2'],
 		];
 
-		public function getRaw(string $className, bool $flag): array {
-			return $this->configs[$className] ?? [];
+		public function getRaw(string $className, bool $flag): ?array {
+			return $this->configs[$className] ?? null;
 		}
 	};
 }

--- a/tests/Vars/Strings/Charset/CharsetConvertIconvTest.php
+++ b/tests/Vars/Strings/Charset/CharsetConvertIconvTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Vars\Strings\Charset;
 
+use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use Hubbitus\HuPHP\Vars\Strings\Charset\CharsetConvert;
 use Hubbitus\HuPHP\Vars\Strings\Charset\CharsetConvertIconv;
-use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Vars/Strings/Charset/CharsetConvertTest.php
+++ b/tests/Vars/Strings/Charset/CharsetConvertTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Hubbitus\Tests\HuPHP\Vars\Strings\Charset;
 
-use Hubbitus\HuPHP\Vars\Strings\Charset\CharsetConvert;
 use Hubbitus\HuPHP\Exceptions\Variables\VariableRequiredException;
+use Hubbitus\HuPHP\Vars\Strings\Charset\CharsetConvert;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Vars/VariableStreamTest.php
+++ b/tests/Vars/VariableStreamTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Hubbitus\HuPHP\Tests\Vars;
 
+use Hubbitus\HuPHP\Vars\VariableStream;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -292,7 +293,7 @@ class VariableStreamTest extends TestCase {
 		// Unregister first to test registration
 		\stream_wrapper_unregister('var');
 
-		$result = \Hubbitus\HuPHP\Vars\VariableStream::registerStreamWrapper();
+		$result = VariableStream::registerStreamWrapper();
 
 		$this->assertTrue($result);
 		$this->assertContains('var', \stream_get_wrappers());
@@ -303,10 +304,10 @@ class VariableStreamTest extends TestCase {
 		// (wrapper already registered)
 
 		// Ensure it's registered
-		\Hubbitus\HuPHP\Vars\VariableStream::registerStreamWrapper();
+		VariableStream::registerStreamWrapper();
 
 		// Second call should return false
-		$result = \Hubbitus\HuPHP\Vars\VariableStream::registerStreamWrapper();
+		$result = VariableStream::registerStreamWrapper();
 
 		$this->assertFalse($result);
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,3 +22,7 @@ require_once $rootDir . '/Vars/CONF.php';
 // This is needed for tests that use var:// protocol
 require_once $rootDir . '/Vars/VariableStream.php';
 
+// Load SingleDefTest.bootstrap.php to define CONF() function for SingleDefTest
+// This is needed because SingleDefTest requires CONF() function to be defined
+require_once $rootDir . '/tests/Vars/SingleDefTest.bootstrap.php';
+


### PR DESCRIPTION
Style: enforce use statements instead of FQCN with php-cs-fixer

- Add `fully_qualified_strict_types` rule to require use statements
- Add `no_leading_import_slash` rule to remove leading backslash from imports
- Add `no_unused_imports` rule to remove unused use statements
- Add `ordered_imports` rule to sort imports alphabetically
- Auto-fix 76 files to comply with new rules

Coverage maintained:
  Classes: 100.00% (59/59)
  Methods: 100.00% (439/439)
  Lines:   100.00% (1903/1903)
